### PR TITLE
Fix GitHub URL parser

### DIFF
--- a/utils/github.ts
+++ b/utils/github.ts
@@ -9,14 +9,20 @@ export const parseGitHubURL = (input: string): string | null => {
     if (url.hostname === 'github.com' || url.hostname === 'www.github.com') {
       const pathSegments = url.pathname.split('/').filter(Boolean);
       if (pathSegments.length >= 2) {
-        const [owner, repo] = pathSegments;
+        const [owner, repoSegment] = pathSegments;
+        const repo = repoSegment.replace(/\.git$/, '');
         return `${owner}/${repo}`;
       }
     }
   } catch {
     // Direct "org/repo" input without full URL
     const match = input.match(/^([^/]+)\/([^/]+)$/);
-    return match ? input : null;
+    if (match) {
+      const [, owner, repoSegment] = match;
+      const repo = repoSegment.replace(/\.git$/, '');
+      return `${owner}/${repo}`;
+    }
+    return null;
   }
   return null;
 };


### PR DESCRIPTION
## Summary
- handle `.git` suffixes in GitHub URLs so repo names resolve correctly

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f823b08b48327a5c6db7e7af908bf