### PR TITLE
Fix JSDoc return type

### DIFF
--- a/lib/clickhouse.ts
+++ b/lib/clickhouse.ts
@@ -56,8 +56,8 @@ export const buildQuery = (
 /**
  * Fetches data from ClickHouse using the generated SQL query.
  * @param {string} query - The SQL query to execute.
- * @returns {Promise<any[]>} - The response data as an array of results.
- */
+ * @returns {Promise<RelatedRepo[]>} - The response data as an array of results.
+*/
 export const fetchDataFromClickHouse = async (query: string): Promise<RelatedRepo[]> => {
   const url = 'https://play.clickhouse.com/?user=explorer';
   const controller = new AbortController();


### PR DESCRIPTION
## Summary
- correct the return type for `fetchDataFromClickHouse`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f83d6f4b083278371bd825d0a55f2