### PR TITLE
Add vitest setup and tests for parseGitHubURL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.0",
@@ -27,5 +28,6 @@
     "tailwindcss": "^3.4.1",
     "eslint": "^8",
     "eslint-config-next": "15.0.2"
+    ,"vitest": "^1.0.0"
   }
 }

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseGitHubURL } from '../../utils/github';
+
+describe('parseGitHubURL', () => {
+  it('handles plain owner/repo format', () => {
+    expect(parseGitHubURL('owner/repo')).toBe('owner/repo');
+  });
+
+  it('parses full GitHub URL', () => {
+    expect(parseGitHubURL('https://github.com/owner/repo')).toBe('owner/repo');
+  });
+
+  it('parses GitHub URL with www', () => {
+    expect(parseGitHubURL('https://www.github.com/owner/repo')).toBe('owner/repo');
+  });
+
+  it('handles trailing slashes', () => {
+    expect(parseGitHubURL('https://github.com/owner/repo/')).toBe('owner/repo');
+  });
+
+  it('parses URLs with extra path segments', () => {
+    expect(parseGitHubURL('https://github.com/owner/repo/issues')).toBe('owner/repo');
+  });
+
+  it('returns null for non-GitHub URLs', () => {
+    expect(parseGitHubURL('https://example.com/owner/repo')).toBeNull();
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseGitHubURL('not a url')).toBeNull();
+  });
+
+  it('returns null for incomplete repo names', () => {
+    expect(parseGitHubURL('owner')).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- set up vitest config and test script
- add unit tests for `parseGitHubURL`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f83d8164883279d7cf646f4de9520