### PR TITLE
Fix parseGitHubURL for URLs without protocol

### DIFF
--- a/utils/github.test.ts
+++ b/utils/github.test.ts
@@ -75,6 +75,10 @@ describe("parseGitHubURL", () => {
     expect(parseGitHubURL("http://github.com/owner/repo")).toBe("owner/repo");
   });
 
+  it("parses URLs without protocol", () => {
+    expect(parseGitHubURL("github.com/owner/repo")).toBe("owner/repo");
+  });
+
   it("handles repos with dots in name", () => {
     expect(parseGitHubURL("owner/repo.name")).toBe("owner/repo.name");
   });

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -4,8 +4,14 @@
  * @returns {string | null} The parsed repository name or null if the URL is invalid.
  */
 export const parseGitHubURL = (input: string): string | null => {
+  // If the input looks like a github.com URL but is missing a protocol,
+  // prepend https:// so URL parsing succeeds.
+  const normalized = /^(?:www\.)?github\.com\//.test(input)
+    ? `https://${input.replace(/^https?:\/\//, "")}`
+    : input;
+
   try {
-    const url = new URL(input);
+    const url = new URL(normalized);
     if (url.hostname === "github.com" || url.hostname === "www.github.com") {
       const pathSegments = url.pathname.split("/").filter(Boolean);
       if (pathSegments.length >= 2) {


### PR DESCRIPTION
## Summary
- handle URLs missing protocol in `parseGitHubURL`
- add regression test

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_683fe0c974688327b1e2735c18158851